### PR TITLE
Fixes locked controls after Transforming

### DIFF
--- a/include/transform.h
+++ b/include/transform.h
@@ -4,7 +4,7 @@
 void TryCreatePokemonAvatarSpriteBob(void);
 void Task_CreatePokemonAvatarBob(u8 taskId);
 void Task_PokemonAvatar_HandleBob(u8 taskId);
-void UpdatePlayerTransformAnimation(struct Sprite *sprite);
+void UpdatePlayerTransformAnimation(u8 taskId);
 
 void BeginPlayerTransformEffect(u8 type);
 

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -789,12 +789,6 @@ static void PlayerNotOnBikeTurningInPlace(u8 direction, u16 heldKeys)
 static void PlayerNotOnBikeMoving(u8 direction, u16 heldKeys)
 {
     u8 collision = CheckForPlayerAvatarCollision(direction);
-    if (gPlayerTransformEffectActive)
-    {
-        struct Sprite *playerSprite = &gSprites[gPlayerAvatar.spriteId];
-        UpdatePlayerTransformAnimation(playerSprite);
-        return;
-    }
     if (collision)
     {
         if (collision == COLLISION_LEDGE_JUMP)


### PR DESCRIPTION
Avoids setting a Sprite callback within the Player's Sprite. Instead opting for a task.

Could probably use some clean-up.