### PR TITLE
Fixes some field move bugs

### DIFF
--- a/asm/macros/event.inc
+++ b/asm/macros/event.inc
@@ -2659,15 +2659,6 @@
 	.2byte \battlePartner
 	.endm
 
-    @ Checks if any Pokémon in the party can learn a specific HM.
-	@ If so, VAR_RESULT is set to the
-	@ (zero-indexed) slot number of the first Pokemon that knows the move. If not, VAR_RESULT is set to PARTY_SIZE.
-	@ VAR_0x8004 is also set to this Pokemon's species.
-	.macro checkpartylearnknowsfieldmove tmhm:req
-	.byte 0xe3
-	.2byte \tmhm
-	.endm
-
 	@ Transforms the Player Ditto into a specific Pokemon
 	.macro dittotransform species:req
 	callnative SetPlayerAvatarFromScript, requests_effects=1

--- a/data/script_cmd_table.inc
+++ b/data/script_cmd_table.inc
@@ -252,7 +252,6 @@ gScriptCmdTable::
 	script_cmd_table_entry SCR_OP_DYNMULTICHOICE                ScrCmd_dynmultichoice,              requests_effects=1  @ 0xe3
 	script_cmd_table_entry SCR_OP_DYNMULTIPUSH                  ScrCmd_dynmultipush,                requests_effects=1  @ 0xe4
 	script_cmd_table_entry SCR_OP_SETSPEAKER 			        ScrCmd_setspeaker,        			requests_effects=1  @ 0xe5
-	script_cmd_table_entry SCR_OP_QOLFIELDMOVE					ScrCmd_checkpartylearnknowsfieldmove requests_effects=1 @ 0xe6 // qol_field_moves
 	
 	.if ALLOCATE_SCRIPT_CMD_TABLE
 gScriptCmdTableEnd::

--- a/data/scripts/field_move_scripts.inc
+++ b/data/scripts/field_move_scripts.inc
@@ -1,9 +1,8 @@
 @ Interact with cuttable tree
 EventScript_CutTree::
 	lockall
-	//checkpartymove MOVE_CUT
-    checkpartylearnknowsfieldmove ITEM_HM01
 	goto_if_unset FLAG_BADGE01_GET, EventScript_CheckTreeCantCut
+	checkpartymove MOVE_CUT
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_CheckTreeCantCut
 	setfieldeffectargument 0, VAR_RESULT
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
@@ -14,14 +13,13 @@ EventScript_CutTree::
 	closemessage
 EventScript_CutTreeCommon:
 	isfollowerfieldmoveuser VAR_0x8004
-	setfieldeffectargument 3, VAR_0x8004 @ skip pose if so
 	isdittofieldmoveuser VAR_0x8004
 	setfieldeffectargument 3, VAR_RESULT
 	dofieldeffect FLDEFF_USE_CUT_ON_TREE
 	waitstate
 EventScript_CutTreeDown:: @ fallthrough
 	setflag FLAG_SAFE_FOLLOWER_MOVEMENT
-	call_if_eq VAR_0x8004, TRUE, EventScript_FollowerFieldMove
+	call_if_eq VAR_0x8004, 1, EventScript_FollowerFieldMove
 	setflag FLAG_SYS_USE_CUT @ qol_field_moves
 	applymovement VAR_LAST_TALKED, Movement_CutTreeDown
 	waitmovement 0
@@ -68,9 +66,8 @@ EventScript_UseRockSmash::
 @ Interact with smashable rock
 EventScript_RockSmash::
 	lockall
-	//checkpartymove MOVE_ROCK_SMASH
-    checkpartylearnknowsfieldmove ITEM_HM06
 	goto_if_unset FLAG_BADGE03_GET, EventScript_CantSmashRock
+	checkpartymove MOVE_ROCK_SMASH
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_CantSmashRock
 	setfieldeffectargument 0, VAR_RESULT
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
@@ -82,14 +79,13 @@ EventScript_RockSmash::
 EventScript_RockSmashCommon:
 	@ check if follower should use the field move
 	isfollowerfieldmoveuser VAR_0x8004
-	setfieldeffectargument 3, VAR_0x8004 @ skip pose if so
 	isdittofieldmoveuser VAR_0x8004
 	setfieldeffectargument 3, VAR_RESULT
 	dofieldeffect FLDEFF_USE_ROCK_SMASH
 	waitstate
 EventScript_SmashRock:: @ fallthrough
 	setflag FLAG_SAFE_FOLLOWER_MOVEMENT
-	call_if_eq VAR_0x8004, TRUE, EventScript_FollowerFieldMove
+	call_if_eq VAR_0x8004, 1, EventScript_FollowerFieldMove
 	setflag FLAG_SYS_USE_ROCK_SMASH @ qol_field_moves
 	applymovement VAR_LAST_TALKED, Movement_SmashRock
 	waitmovement 0
@@ -235,8 +231,7 @@ EventScript_StrengthBoulder::
 	lockall
 	goto_if_unset FLAG_BADGE04_GET, EventScript_CantStrength
 	goto_if_set FLAG_SYS_USE_STRENGTH, EventScript_CheckActivatedBoulder
-	//checkpartymove MOVE_STRENGTH
-    checkpartylearnknowsfieldmove ITEM_HM04
+    checkpartymove MOVE_STRENGTH
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_CantStrength
 	setfieldeffectargument 0, VAR_RESULT
 	msgbox Text_WantToStrength, MSGBOX_YESNO
@@ -301,8 +296,7 @@ Text_StrengthActivated:
 
 EventScript_UseWaterfall::
 	lockall
-	//checkpartymove MOVE_WATERFALL
-    checkpartylearnknowsfieldmove ITEM_HM07
+    checkpartymove MOVE_WATERFALL
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_CantWaterfall
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
@@ -339,8 +333,7 @@ Text_MonUsedWaterfall:
 
 EventScript_UseDive::
 	lockall
-	//checkpartymove MOVE_DIVE
-    checkpartylearnknowsfieldmove ITEM_HM08
+    checkpartymove MOVE_DIVE
 	goto_if_eq VAR_RESULT, FALSE, EventScript_CantDive
 	copyvar 0x8004 VAR_RESULT
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
@@ -367,8 +360,7 @@ EventScript_EndDive::
 
 EventScript_UseDiveUnderwater::
 	lockall
-	//checkpartymove MOVE_DIVE
-    checkpartylearnknowsfieldmove ITEM_HM08
+    checkpartymove MOVE_DIVE
 	goto_if_eq VAR_RESULT, FALSE, EventScript_CantSurface
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT
@@ -395,14 +387,13 @@ EventScript_NoSurface::
 
 EventScript_DigCommon:
 	isfollowerfieldmoveuser VAR_0x8004
-	setfieldeffectargument 3, VAR_0x8004 @ skip pose if true
 	isdittofieldmoveuser VAR_0x8004
 	setfieldeffectargument 3, VAR_RESULT
 	dofieldeffect FLDEFF_USE_DIG
 	waitstate
 EventScript_DigSealedChamber:: @ fallthrough
 	setflag FLAG_SAFE_FOLLOWER_MOVEMENT
-	call_if_eq VAR_0x8004, TRUE, EventScript_FollowerFieldMove
+	call_if_eq VAR_0x8004, 1, EventScript_FollowerFieldMove
 	callnative DoBrailleDigEffect
 	releaseall
 	end
@@ -415,7 +406,6 @@ EventScript_UseDig::
 
 EventScript_CutGrassCommon:
 	isfollowerfieldmoveuser VAR_0x8004
-	setfieldeffectargument 3, VAR_0x8004 @ skip pose if true
 	isdittofieldmoveuser VAR_0x8004
 	setfieldeffectargument 3, VAR_RESULT
 	dofieldeffect FLDEFF_USE_CUT_ON_GRASS
@@ -459,11 +449,10 @@ EventScript_UseDefog::
 	msgbox Text_MonUsedFieldMove, MSGBOX_DEFAULT
 	closemessage
 	isfollowerfieldmoveuser VAR_0x8004
-	setfieldeffectargument 3, VAR_0x8004 @ skip pose if so
 	isdittofieldmoveuser VAR_0x8004
 	setfieldeffectargument 3, VAR_RESULT
 	setflag FLAG_SAFE_FOLLOWER_MOVEMENT
-	call_if_eq VAR_0x8004, TRUE, EventScript_FollowerFieldMove
+	call_if_eq VAR_0x8004, 1, EventScript_FollowerFieldMove
 	waitmovement 0
 	setfieldeffectargument 0, VAR_RESULT
 	dofieldeffect FLDEFF_DEFOG

--- a/data/scripts/surf.inc
+++ b/data/scripts/surf.inc
@@ -1,6 +1,5 @@
 EventScript_UseSurf::
-	//checkpartymove MOVE_SURF
-    checkpartylearnknowsfieldmove ITEM_HM03
+    checkpartymove MOVE_SURF
 	goto_if_eq VAR_RESULT, PARTY_SIZE, EventScript_EndUseSurf
 	bufferpartymonnick STR_VAR_1, VAR_RESULT
 	setfieldeffectargument 0, VAR_RESULT

--- a/include/transform.h
+++ b/include/transform.h
@@ -2,7 +2,7 @@
 #define GUARD_TRANSFORM_H
 
 bool32 PlayerIsDitto(void);
-void BeginPlayerTransformEffect(u8 type);
+void BeginPlayerTransformEffect(u8 type, bool8 unlockPlayerFieldControls);
 u16 GetValidTransformationSpeciesFromParty(u8 partyId);
 u8 BlitTransformationIconToWindow(u16 speciesId, u8 windowId, u16 x, u16 y, void *paletteDest);
 
@@ -18,8 +18,8 @@ u16 ReturnAvatarTrainerBackPicId(u16 avatarId);
 
 typedef void (*TransformFunc)(u8);
 
-void SetPlayerAvatarTransformation(u16 speciesId);
-void TrySetPlayerAvatarTransformation(u16 speciesId);
+void SetPlayerAvatarTransformation(u16 speciesId, bool8 UnlockPlayerFieldControls);
+void TrySetPlayerAvatarTransformation(u16 speciesId, bool8 UnlockPlayerFieldControls);
 TransformFunc GetTransformationFunc(u16 speciesId);
 
 #define TRANSFORM_TYPE_PLAYER_SPECIES 1

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1734,7 +1734,7 @@ void SetPlayerAvatarFieldMove(void)
 {
     if (PlayerIsDitto())
     {
-        TrySetPlayerAvatarTransformation(GetMonData(&gPlayerParty[(u8)gFieldEffectArguments[0]], MON_DATA_SPECIES));
+        TrySetPlayerAvatarTransformation(GetMonData(&gPlayerParty[(u8)gFieldEffectArguments[0]], MON_DATA_SPECIES), FALSE);
     }
     else
     {

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -1630,7 +1630,7 @@ void ItemUseOutOfBattle_StrengthTransform(u8 taskId)
 void ItemUseOnFieldCB_StrengthTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_MACHAMP);
+    SetPlayerAvatarTransformation(SPECIES_MACHAMP, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1643,7 +1643,7 @@ void ItemUseOutOfBattle_DittoTransform(u8 taskId)
 void ItemUseOnFieldCB_DittoTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_DITTO);
+    SetPlayerAvatarTransformation(SPECIES_DITTO, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1656,7 +1656,7 @@ void ItemUseOutOfBattle_SurfTransform(u8 taskId)
 void ItemUseOnFieldCB_SurfTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_MARILL);
+    SetPlayerAvatarTransformation(SPECIES_MARILL, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1669,7 +1669,7 @@ void ItemUseOutOfBattle_ShrinkTransform(u8 taskId)
 void ItemUseOnFieldCB_ShrinkTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_CUTIEFLY);
+    SetPlayerAvatarTransformation(SPECIES_CUTIEFLY, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1682,7 +1682,7 @@ void ItemUseOutOfBattle_FlyTransform(u8 taskId)
 void ItemUseOnFieldCB_FlyTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_NOIVERN);
+    SetPlayerAvatarTransformation(SPECIES_NOIVERN, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1695,7 +1695,7 @@ void ItemUseOutOfBattle_RockSmashTransform(u8 taskId)
 void ItemUseOnFieldCB_RockSmashTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_RHYHORN);
+    SetPlayerAvatarTransformation(SPECIES_RHYHORN, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1708,7 +1708,7 @@ void ItemUseOutOfBattle_DiveTransform(u8 taskId)
 void ItemUseOnFieldCB_DiveTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_CHINCHOU);
+    SetPlayerAvatarTransformation(SPECIES_CHINCHOU, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1721,7 +1721,7 @@ void ItemUseOutOfBattle_WaterfallTransform(u8 taskId)
 void ItemUseOnFieldCB_WaterfallTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_DRAGONAIR);
+    SetPlayerAvatarTransformation(SPECIES_DRAGONAIR, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1734,7 +1734,7 @@ void ItemUseOutOfBattle_MachBikeTransform(u8 taskId)
 void ItemUseOnFieldCB_MachBikeTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_ARCANINE);
+    SetPlayerAvatarTransformation(SPECIES_ARCANINE, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1747,7 +1747,7 @@ void ItemUseOutOfBattle_AcroBikeTransform(u8 taskId)
 void ItemUseOnFieldCB_AcroBikeTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_WEAVILE);
+    SetPlayerAvatarTransformation(SPECIES_WEAVILE, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1760,7 +1760,7 @@ void ItemUseOutOfBattle_CutTransform(u8 taskId)
 void ItemUseOnFieldCB_CutTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_LURANTIS);
+    SetPlayerAvatarTransformation(SPECIES_LURANTIS, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }
@@ -1773,7 +1773,7 @@ void ItemUseOutOfBattle_FlashTransform(u8 taskId)
 void ItemUseOnFieldCB_FlashTransform(u8 taskId)
 {
     LockPlayerFieldControls();
-    SetPlayerAvatarTransformation(SPECIES_PIKACHU);
+    SetPlayerAvatarTransformation(SPECIES_PIKACHU, TRUE);
     ScriptUnfreezeObjectEvents();
     DestroyTask(taskId);
 }

--- a/src/qol_field_moves.c
+++ b/src/qol_field_moves.c
@@ -623,18 +623,12 @@ bool32 PartyHasMonLearnsKnowsFieldMove(u16 itemId)
 bool32 LeadMonKnowsFieldMove(u16 itemId)
 {
     struct Pokemon *mon;
-    u32 species, monCanLearnTM;
     u16 moveId = ItemIdToBattleMoveId(itemId);
     gSpecialVar_0x8004 = 0;
-
     mon = &gPlayerParty[0];
-    species = GetMonData(mon, MON_DATA_SPECIES, NULL);
 
-    monCanLearnTM = CanTeachMove(mon,moveId);
-    if ((PartyCanLearnMoveLevelUp(species, moveId)
-            || (monCanLearnTM) == ALREADY_KNOWS_MOVE)
-            || (monCanLearnTM) == CAN_LEARN_MOVE)
-        return SetMonResultVariables(0 ,species);
+    if (!GetMonData(mon, MON_DATA_IS_EGG) && MonKnowsMove(mon, moveId) == TRUE)
+        return TRUE;
 
     return FALSE;
 }

--- a/src/scrcmd.c
+++ b/src/scrcmd.c
@@ -3261,15 +3261,3 @@ void Script_EndTrainerCanSeeIf(struct ScriptContext *ctx)
     if (ctx->breakOnTrainerBattle && sScriptConditionTable[condition][ctx->comparisonResult] == 1)
         StopScript(ctx);
 }
-
-// Start qol_field_moves
-bool8 ScrCmd_checkpartylearnknowsfieldmove(struct ScriptContext *ctx)
-{
-    u16 machine = ScriptReadHalfword(ctx);
-
-    PartyHasMonLearnsKnowsFieldMove(machine);
-
-    return FALSE;
-}
-// End qol_field_moves
-


### PR DESCRIPTION
This PR includes:

- Fixes an issue where gSpecialVar_LastTalked was reset to 0 when a transformation happens, which would cause rocks and trees not to be smashed/cut properly after transforming for a field move from the party menu.
- Fixes an issue where interacting with a field script to preform a field move would freeze the game
- Adjusts the behavior of the field move check so that it no longer returns TRUE when a mon can learn a move. Only when the mon KNOWS the move.