### PR TITLE
Transform Switch

### DIFF
--- a/data/battle_scripts_1.s
+++ b/data/battle_scripts_1.s
@@ -3465,6 +3465,7 @@ BattleScript_EffectTransform::
 	ppreduce
 	trytoclearprimalweather
 	flushtextbox
+BattleScript_TransformFromPartyMenu::
 	transformdataexecution
 	attackanimation
 	waitanimation

--- a/include/battle.h
+++ b/include/battle.h
@@ -1136,6 +1136,8 @@ extern bool8 gLastUsedBallMenuPresent;
 extern u8 gPartyCriticalHits[PARTY_SIZE];
 extern u8 gCategoryIconSpriteId;
 
+extern u8 gPartyTargetForTransform;
+
 static inline bool32 IsBattlerAlive(u32 battler)
 {
     if (gBattleMons[battler].hp == 0)

--- a/include/battle_scripts.h
+++ b/include/battle_scripts.h
@@ -623,6 +623,7 @@ extern const u8 BattleScript_EffectSpecialDefenseUp2[];
 extern const u8 BattleScript_EffectAccuracyUp2[];
 extern const u8 BattleScript_EffectEvasionUp2[];
 extern const u8 BattleScript_EffectTransform[];
+extern const u8 BattleScript_TransformFromPartyMenu[];
 extern const u8 BattleScript_EffectAttackDown2[];
 extern const u8 BattleScript_EffectDefenseDown2[];
 extern const u8 BattleScript_EffectSpeedDown2[];

--- a/include/transform.h
+++ b/include/transform.h
@@ -23,6 +23,8 @@ void TrySetPlayerAvatarTransformation(u16 speciesId, bool8 UnlockPlayerFieldCont
 void SetPlayerAvatarSurfTransformation(u16 speciesId, bool8 UnlockPlayerFieldControls);
 void SetPlayerAvatarStopSurfTransformation(u16 speciesId, bool8 UnlockPlayerFieldControls);
 TransformFunc GetTransformationFunc(u16 speciesId);
+u16 GetTransformationMoves(u16 speciesId, u8 i);
+u16 GetTransformationAbility(u16 speciesId);
 
 #define TRANSFORM_TYPE_PLAYER_SPECIES 1
 

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -254,6 +254,8 @@ COMMON_DATA u8 gHealthboxSpriteIds[MAX_BATTLERS_COUNT] = {0};
 COMMON_DATA u8 gMultiUsePlayerCursor = 0;
 COMMON_DATA u8 gNumberOfMovesToChoose = 0;
 
+EWRAM_DATA u8 gPartyTargetForTransform = 0;
+
 static const struct ScanlineEffectParams sIntroScanlineParams16Bit =
 {
     &REG_BG3HOFS, SCANLINE_EFFECT_DMACNT_16BIT, 1

--- a/src/battle_util.c
+++ b/src/battle_util.c
@@ -24,6 +24,7 @@
 #include "string_util.h"
 #include "task.h"
 #include "test_runner.h"
+#include "transform.h"
 #include "trig.h"
 #include "trainer_slide.h"
 #include "window.h"
@@ -552,6 +553,17 @@ void HandleAction_Switch(void)
      && gBattlerPartyIndexes[BATTLE_PARTNER(gBattlerAttacker)] == gBattleStruct->monToSwitchIntoId[gBattlerAttacker])
     {
         gCurrentActionFuncId = B_ACTION_FINISHED;
+        return;
+    }
+
+    // if playing as Ditto, cancel switch
+    if (PlayerIsDitto())
+    {
+        gPartyTargetForTransform = gBattleStruct->monToSwitchIntoId[gBattlerAttacker];
+        DebugPrintfLevel(MGBA_LOG_WARN, "gPartyTargetForTransform (%d)!", gPartyTargetForTransform);
+        gBattlescriptCurrInstr = BattleScript_TransformFromPartyMenu;
+        gCurrentMove = gChosenMove = MOVE_TRANSFORM;
+        gCurrentActionFuncId = B_ACTION_EXEC_SCRIPT;
         return;
     }
 

--- a/src/transform.c
+++ b/src/transform.c
@@ -227,6 +227,16 @@ TransformFunc GetTransformationFunc(u16 speciesId)
     return gTransformations[speciesId].fieldUseFunc;
 }
 
+u16 GetTransformationMoves(u16 speciesId, u8 i)
+{
+    return gTransformations[speciesId].moves[i];
+}
+
+u16 GetTransformationAbility(u16 speciesId)
+{
+    return gTransformations[speciesId].ability;
+}
+
 void TransformDittoBoxMon(u16 targetSpecies)
 {
     if (!IsSpeciesValidTransformation(targetSpecies))


### PR DESCRIPTION
Using switch from the party menu in battle causes Ditto to transform into the chosen party member.
Caveats:
- Transforming into a party member sets all moves to 5pp. Thus you'll never run out of pp (I don't see this being a problem in the scope of our hack).
- Transforming into a mon with higher max hp slightly increases ditto's current hp (I don't see this being a problem since it's so minor and it costs your entire turn to transform).
- The final boss battle seems to promote you to transform into Mew. This mechanic currently allows you to bypass this and swap back to a learned transformation. We can possibly just disable switching in this battle if necessary.