### PR TITLE
Critical hit fix

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -2078,6 +2078,8 @@ static void Cmd_critcalc(void)
             gSpecialStatuses[battlerDef].criticalHit = FALSE;
         else if (gBattleStruct->critChance[battlerDef] == -2)
             gSpecialStatuses[battlerDef].criticalHit = TRUE;
+        else if (PlayerIsDitto()) // Disable non-guarenteed crits
+            gSpecialStatuses[battlerDef].criticalHit = FALSE;
         else
         {
             if (GetGenConfig(GEN_CONFIG_CRIT_CHANCE) == GEN_1)

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -1970,6 +1970,9 @@ s32 CalcCritChanceStage(u32 battlerAtk, u32 battlerDef, u32 move, bool32 recordA
         critChance = CRITICAL_HIT_BLOCKED;
     }
 
+    if (critChance != CRITICAL_HIT_ALWAYS)
+        critChance = CRITICAL_HIT_BLOCKED;
+
     return critChance;
 }
 


### PR DESCRIPTION
This should entirely disable random crits.
I think it was possible for 0 to be returned from the `CalcCritChanceStage` function previously.